### PR TITLE
Made it possible to disable the deletion of Unknown Commands with SmartQueue

### DIFF
--- a/src/main/java/com/dynxsty/dih4jda/DIH4JDA.java
+++ b/src/main/java/com/dynxsty/dih4jda/DIH4JDA.java
@@ -34,7 +34,7 @@ public class DIH4JDA extends ListenerAdapter {
 	private final Set<DIH4JDALogger.Type> blockedLogTypes;
 	private final boolean registerOnStartup;
 	private final boolean smartQueuing;
-	private final boolean smartQueueDeleteUnknown;
+	private final boolean deleteUnknownCommands;
 	private final Set<DIH4JDAListenerAdapter> listeners;
 	private final Executor executor;
 	private InteractionHandler handler;
@@ -46,12 +46,12 @@ public class DIH4JDA extends ListenerAdapter {
 	 * @param commandsPackage The package that houses the command classes.
 	 * @param blockedLogTypes All Logs that should be blocked.
 	 */
-	protected DIH4JDA(JDA jda, String commandsPackage, boolean registerOnStartup, boolean smartQueuing, boolean smartQueueDeleteUnknown, Executor executor, DIH4JDALogger.Type... blockedLogTypes) {
+	protected DIH4JDA(JDA jda, String commandsPackage, boolean registerOnStartup, boolean smartQueuing, boolean deleteUnknownCommands, Executor executor, DIH4JDALogger.Type... blockedLogTypes) {
 		this.jda = jda;
 		this.commandsPackage = commandsPackage;
 		this.registerOnStartup = registerOnStartup;
 		this.smartQueuing = smartQueuing;
-		this.smartQueueDeleteUnknown = smartQueueDeleteUnknown;
+		this.deleteUnknownCommands = deleteUnknownCommands;
 		if (blockedLogTypes == null || blockedLogTypes.length < 1) {
 			this.blockedLogTypes = new HashSet<>();
 		} else {
@@ -133,8 +133,8 @@ public class DIH4JDA extends ListenerAdapter {
 	/**
 	 * @return Whether the SmartQueueDeleteUnknown functionality is enabled.
 	 */
-	public boolean isSmartQueueDeletingUnknown() {
-		return smartQueueDeleteUnknown;
+	public boolean isDeletingUnknownCommands() {
+		return deleteUnknownCommands;
 	}
 
 	/**

--- a/src/main/java/com/dynxsty/dih4jda/DIH4JDA.java
+++ b/src/main/java/com/dynxsty/dih4jda/DIH4JDA.java
@@ -34,6 +34,7 @@ public class DIH4JDA extends ListenerAdapter {
 	private final Set<DIH4JDALogger.Type> blockedLogTypes;
 	private final boolean registerOnStartup;
 	private final boolean smartQueuing;
+	private final boolean smartQueueDeleteUnknown;
 	private final Set<DIH4JDAListenerAdapter> listeners;
 	private final Executor executor;
 	private InteractionHandler handler;
@@ -45,11 +46,12 @@ public class DIH4JDA extends ListenerAdapter {
 	 * @param commandsPackage The package that houses the command classes.
 	 * @param blockedLogTypes All Logs that should be blocked.
 	 */
-	protected DIH4JDA(JDA jda, String commandsPackage, boolean registerOnStartup, boolean smartQueuing, Executor executor, DIH4JDALogger.Type... blockedLogTypes) {
+	protected DIH4JDA(JDA jda, String commandsPackage, boolean registerOnStartup, boolean smartQueuing, boolean smartQueueDeleteUnknown, Executor executor, DIH4JDALogger.Type... blockedLogTypes) {
 		this.jda = jda;
 		this.commandsPackage = commandsPackage;
 		this.registerOnStartup = registerOnStartup;
 		this.smartQueuing = smartQueuing;
+		this.smartQueueDeleteUnknown = smartQueueDeleteUnknown;
 		if (blockedLogTypes == null || blockedLogTypes.length < 1) {
 			this.blockedLogTypes = new HashSet<>();
 		} else {
@@ -122,10 +124,17 @@ public class DIH4JDA extends ListenerAdapter {
 	}
 
 	/**
-	 * @return Whether the SmartQueue Functionality is enabled.
+	 * @return Whether the SmartQueue functionality is enabled.
 	 */
 	public boolean isSmartQueuing() {
 		return smartQueuing;
+	}
+
+	/**
+	 * @return Whether the SmartQueueDeleteUnknown functionality is enabled.
+	 */
+	public boolean isSmartQueueDeletingUnknown() {
+		return smartQueueDeleteUnknown;
 	}
 
 	/**

--- a/src/main/java/com/dynxsty/dih4jda/DIH4JDABuilder.java
+++ b/src/main/java/com/dynxsty/dih4jda/DIH4JDABuilder.java
@@ -87,7 +87,7 @@ public class DIH4JDABuilder {
 	 * This will disable the Smart Queueing functionality.
 	 * If Smart Queueing is disabled Global Slash/Context Commands get overridden on each {@link DIH4JDA#registerInteractions()} call,
 	 * thus, making Global Commands unusable for about an hour, until they're registered again. <br>
-	 * By default, this also deletes unknown commands. This behaviour can be disabled with {@link DIH4JDABuilder#disableSmartQueueRemoveUnknown()}.
+	 * By default, this also deletes unknown/unused commands. This behaviour can be disabled with {@link DIH4JDABuilder#disableSmartQueueRemoveUnknown()}.
 	 */
 	@Nonnull
 	public DIH4JDABuilder disableSmartQueuing() {

--- a/src/main/java/com/dynxsty/dih4jda/DIH4JDABuilder.java
+++ b/src/main/java/com/dynxsty/dih4jda/DIH4JDABuilder.java
@@ -19,7 +19,7 @@ public class DIH4JDABuilder {
 	private DIH4JDALogger.Type[] blockedLogTypes;
 	private boolean registerOnStartup = true;
 	private boolean smartQueuing = true;
-	private boolean smartQueueDeleteUnknown = true;
+	private boolean deleteUnknownCommands = true;
 
 	private DIH4JDABuilder(@Nonnull JDA jda) {
 		this.jda = jda;
@@ -87,7 +87,7 @@ public class DIH4JDABuilder {
 	 * This will disable the Smart Queueing functionality.
 	 * If Smart Queueing is disabled Global Slash/Context Commands get overridden on each {@link DIH4JDA#registerInteractions()} call,
 	 * thus, making Global Commands unusable for about an hour, until they're registered again. <br>
-	 * By default, this also deletes unknown/unused commands. This behaviour can be disabled with {@link DIH4JDABuilder#disableSmartQueueRemoveUnknown()}.
+	 * By default, this also deletes unknown/unused commands. This behaviour can be disabled with {@link DIH4JDABuilder#disableUnknownCommandDeletion()}.
 	 */
 	@Nonnull
 	public DIH4JDABuilder disableSmartQueuing() {
@@ -99,8 +99,8 @@ public class DIH4JDABuilder {
 	 * Disables deletion of unknown/unused commands when using SmartQueue.
 	 */
 	@Nonnull
-	public DIH4JDABuilder disableSmartQueueRemoveUnknown() {
-		smartQueueDeleteUnknown = false;
+	public DIH4JDABuilder disableUnknownCommandDeletion() {
+		deleteUnknownCommands = false;
 		return this;
 	}
 
@@ -118,6 +118,6 @@ public class DIH4JDABuilder {
 		if (ClasspathHelper.forPackage(commandsPackage).isEmpty()) {
 			throw new InvalidPackageException("Package " + commandsPackage + " does not exist.");
 		}
-		return new DIH4JDA(jda, commandsPackage, registerOnStartup, smartQueuing, smartQueueDeleteUnknown, executor, blockedLogTypes);
+		return new DIH4JDA(jda, commandsPackage, registerOnStartup, smartQueuing, deleteUnknownCommands, executor, blockedLogTypes);
 	}
 }

--- a/src/main/java/com/dynxsty/dih4jda/DIH4JDABuilder.java
+++ b/src/main/java/com/dynxsty/dih4jda/DIH4JDABuilder.java
@@ -19,6 +19,7 @@ public class DIH4JDABuilder {
 	private DIH4JDALogger.Type[] blockedLogTypes;
 	private boolean registerOnStartup = true;
 	private boolean smartQueuing = true;
+	private boolean smartQueueDeleteUnknown = true;
 
 	private DIH4JDABuilder(@Nonnull JDA jda) {
 		this.jda = jda;
@@ -86,11 +87,20 @@ public class DIH4JDABuilder {
 	 * This will disable the Smart Queueing functionality.
 	 * If Smart Queueing is disabled Global Slash/Context Commands get overridden on each {@link DIH4JDA#registerInteractions()} call,
 	 * thus, making Global Commands unusable for about an hour, until they're registered again. <br>
-	 * Smart Queuing also includes the automatic removal of unknown/unused Global Interactions.
+	 * By default, this also deletes unknown commands. This behaviour can be disabled with {@link DIH4JDABuilder#disableSmartQueueRemoveUnknown()}.
 	 */
 	@Nonnull
 	public DIH4JDABuilder disableSmartQueuing() {
 		smartQueuing = false;
+		return this;
+	}
+
+	/**
+	 * Disables deletion of unknown/unused commands when using SmartQueue.
+	 */
+	@Nonnull
+	public DIH4JDABuilder disableSmartQueueRemoveUnknown() {
+		smartQueueDeleteUnknown = false;
 		return this;
 	}
 
@@ -108,6 +118,6 @@ public class DIH4JDABuilder {
 		if (ClasspathHelper.forPackage(commandsPackage).isEmpty()) {
 			throw new InvalidPackageException("Package " + commandsPackage + " does not exist.");
 		}
-		return new DIH4JDA(jda, commandsPackage, registerOnStartup, smartQueuing, executor, blockedLogTypes);
+		return new DIH4JDA(jda, commandsPackage, registerOnStartup, smartQueuing, smartQueueDeleteUnknown, executor, blockedLogTypes);
 	}
 }

--- a/src/main/java/com/dynxsty/dih4jda/InteractionHandler.java
+++ b/src/main/java/com/dynxsty/dih4jda/InteractionHandler.java
@@ -156,7 +156,7 @@ public class InteractionHandler extends ListenerAdapter {
 			Pair<Set<SlashCommandData>, Set<CommandData>> data = new Pair<>(getSlashCommandData(guild), getContextCommandData(guild));
 			// check if smart queuing is enabled
 			if (dih4jda.isSmartQueuing()) {
-				data = SmartQueue.checkGuild(guild, data.component1(), data.component2(), dih4jda.isSmartQueueDeletingUnknown());
+				data = SmartQueue.checkGuild(guild, data.component1(), data.component2(), dih4jda.isDeletingUnknownCommands());
 			}
 			// upsert all guild commands
 			if (!data.component1().isEmpty() || !data.component2().isEmpty()) {
@@ -168,7 +168,7 @@ public class InteractionHandler extends ListenerAdapter {
 		Pair<Set<SlashCommandData>, Set<CommandData>> data = new Pair<>(getSlashCommandData(null), getContextCommandData(null));
 		// check if smart queuing is enabled
 		if (dih4jda.isSmartQueuing()) {
-			data = SmartQueue.checkGlobal(dih4jda.getJDA(), data.component1(), data.component2(), dih4jda.isSmartQueueDeletingUnknown());
+			data = SmartQueue.checkGlobal(dih4jda.getJDA(), data.component1(), data.component2(), dih4jda.isDeletingUnknownCommands());
 		}
 		// upsert all global commands
 		if (!data.component1().isEmpty() || !data.component2().isEmpty()) {

--- a/src/main/java/com/dynxsty/dih4jda/InteractionHandler.java
+++ b/src/main/java/com/dynxsty/dih4jda/InteractionHandler.java
@@ -156,7 +156,7 @@ public class InteractionHandler extends ListenerAdapter {
 			Pair<Set<SlashCommandData>, Set<CommandData>> data = new Pair<>(getSlashCommandData(guild), getContextCommandData(guild));
 			// check if smart queuing is enabled
 			if (dih4jda.isSmartQueuing()) {
-				data = SmartQueue.checkGuild(guild, data.component1(), data.component2());
+				data = SmartQueue.checkGuild(guild, data.component1(), data.component2(), dih4jda.isSmartQueueDeletingUnknown());
 			}
 			// upsert all guild commands
 			if (!data.component1().isEmpty() || !data.component2().isEmpty()) {
@@ -168,7 +168,7 @@ public class InteractionHandler extends ListenerAdapter {
 		Pair<Set<SlashCommandData>, Set<CommandData>> data = new Pair<>(getSlashCommandData(null), getContextCommandData(null));
 		// check if smart queuing is enabled
 		if (dih4jda.isSmartQueuing()) {
-			data = SmartQueue.checkGlobal(dih4jda.getJDA(), data.component1(), data.component2());
+			data = SmartQueue.checkGlobal(dih4jda.getJDA(), data.component1(), data.component2(), dih4jda.isSmartQueueDeletingUnknown());
 		}
 		// upsert all global commands
 		if (!data.component1().isEmpty() || !data.component2().isEmpty()) {

--- a/src/main/java/com/dynxsty/dih4jda/SmartQueue.java
+++ b/src/main/java/com/dynxsty/dih4jda/SmartQueue.java
@@ -23,7 +23,7 @@ public class SmartQueue {
 	}
 
 	/**
-	 * Compares CommandData with already existing Commands, removed duplicates and deletes unknown Global Commands.
+	 * Compares CommandData with already existing Commands, removed duplicates and, if enabled, deleted unknown commands.
 	 *
 	 * @param jda         The {@link JDA} instance which is used to retrieve the already existing commands.
 	 * @param slashData   The set of {@link SlashCommandData}.
@@ -31,16 +31,16 @@ public class SmartQueue {
 	 * @return A {@link Pair} with the remaining {@link SlashCommandData} & {@link CommandData}.
 	 * @since v1.5
 	 */
-	protected static Pair<Set<SlashCommandData>, Set<CommandData>> checkGlobal(JDA jda, Set<SlashCommandData> slashData, Set<CommandData> commandData) {
+	protected static Pair<Set<SlashCommandData>, Set<CommandData>> checkGlobal(JDA jda, Set<SlashCommandData> slashData, Set<CommandData> commandData, boolean deleteUnknown) {
 		final List<Command> existing = jda.retrieveCommands().complete();
 		if (!existing.isEmpty()) {
-			return removeDuplicates(jda, existing, slashData, commandData, null);
+			return removeDuplicates(jda, existing, slashData, commandData, null, deleteUnknown);
 		}
 		return new Pair<>(slashData, commandData);
 	}
 
 	/**
-	 * Compares CommandData with already existing Commands, removed duplicates and deletes unknown Guild Commands.
+	 * Compares CommandData with already existing Commands, removed duplicates and, if enabled, deleted unknown commands.
 	 *
 	 * @param guild       The {@link Guild} which is used to retrieve the already existing commands.
 	 * @param slashData   The set of {@link SlashCommandData}.
@@ -48,26 +48,27 @@ public class SmartQueue {
 	 * @return A {@link Pair} with the remaining {@link SlashCommandData} & {@link CommandData}.
 	 * @since v1.5
 	 */
-	protected static Pair<Set<SlashCommandData>, Set<CommandData>> checkGuild(Guild guild, Set<SlashCommandData> slashData, Set<CommandData> commandData) {
+	protected static Pair<Set<SlashCommandData>, Set<CommandData>> checkGuild(Guild guild, Set<SlashCommandData> slashData, Set<CommandData> commandData, boolean deleteUnknown) {
 		final List<Command> existing = guild.retrieveCommands().complete();
 		if (!existing.isEmpty()) {
-			return removeDuplicates(guild.getJDA(), existing, slashData, commandData, guild);
+			return removeDuplicates(guild.getJDA(), existing, slashData, commandData, guild, deleteUnknown);
 		}
 		return new Pair<>(slashData, commandData);
 	}
 
 	/**
-	 * Removes all duplicate CommandData and deletes unknown commands.
+	 * Removes all duplicate CommandData and, if enabled, deletes unknown commands.
 	 *
-	 * @param jda         The {@link JDA} instance.
-	 * @param existing    A List of all existing {@link Command}s.
-	 * @param slashData   The set of {@link SlashCommandData}.
-	 * @param commandData The set of {@link CommandData}.
-	 * @param guild       An optional guild parameter which is used with {@link SmartQueue#checkGuild(Guild, Set, Set)}.
+	 * @param jda         	The {@link JDA} instance.
+	 * @param existing    	A List of all existing {@link Command}s.
+	 * @param slashData   	The set of {@link SlashCommandData}.
+	 * @param commandData 	The set of {@link CommandData}.
+	 * @param guild       	An optional guild parameter which is used with {@link SmartQueue#checkGuild(Guild, Set, Set, boolean)}.
+	 * @param removeUnknown Whether unknown commands should be removed.
 	 * @return A {@link Pair} with the remaining {@link SlashCommandData} & {@link CommandData}.
 	 * @since v1.5
 	 */
-	private static Pair<Set<SlashCommandData>, Set<CommandData>> removeDuplicates(JDA jda, final List<Command> existing, Set<SlashCommandData> slashData, Set<CommandData> commandData, @Nullable Guild guild) {
+	private static Pair<Set<SlashCommandData>, Set<CommandData>> removeDuplicates(JDA jda, final List<Command> existing, Set<SlashCommandData> slashData, Set<CommandData> commandData, @Nullable Guild guild, boolean removeUnknown) {
 		List<Command> commands = new ArrayList<>(existing);
 		boolean global = guild == null;
 		DIH4JDALogger.info(String.format("Found %s existing %s command(s)", existing.size(), global ? "global" : "guild"), DIH4JDALogger.Type.SMART_QUEUE);
@@ -82,8 +83,8 @@ public class SmartQueue {
 		});
 		commandData.removeIf(data -> existing.stream().anyMatch(p -> CommandUtils.isEqual(p, data)));
 		slashData.removeIf(data -> existing.stream().anyMatch(p -> CommandUtils.isEqual(p, data)));
-		// remove unknown commands
-		if (!commands.isEmpty()) {
+		// remove unknown commands, if enabled
+		if (!commands.isEmpty() && removeUnknown) {
 			for (Command command : commands) {
 				if (existing.contains(command)) {
 					DIH4JDALogger.info(String.format("Deleting unknown %s command: %s", command.getType(), command.getName()), DIH4JDALogger.Type.SMART_QUEUE);

--- a/src/main/java/com/dynxsty/dih4jda/SmartQueue.java
+++ b/src/main/java/com/dynxsty/dih4jda/SmartQueue.java
@@ -64,11 +64,11 @@ public class SmartQueue {
 	 * @param slashData   	The set of {@link SlashCommandData}.
 	 * @param commandData 	The set of {@link CommandData}.
 	 * @param guild       	An optional guild parameter which is used with {@link SmartQueue#checkGuild(Guild, Set, Set, boolean)}.
-	 * @param removeUnknown Whether unknown commands should be removed.
+	 * @param deleteUnknown Whether unknown commands should be removed.
 	 * @return A {@link Pair} with the remaining {@link SlashCommandData} & {@link CommandData}.
 	 * @since v1.5
 	 */
-	private static Pair<Set<SlashCommandData>, Set<CommandData>> removeDuplicates(JDA jda, final List<Command> existing, Set<SlashCommandData> slashData, Set<CommandData> commandData, @Nullable Guild guild, boolean removeUnknown) {
+	private static Pair<Set<SlashCommandData>, Set<CommandData>> removeDuplicates(JDA jda, final List<Command> existing, Set<SlashCommandData> slashData, Set<CommandData> commandData, @Nullable Guild guild, boolean deleteUnknown) {
 		List<Command> commands = new ArrayList<>(existing);
 		boolean global = guild == null;
 		DIH4JDALogger.info(String.format("Found %s existing %s command(s)", existing.size(), global ? "global" : "guild"), DIH4JDALogger.Type.SMART_QUEUE);
@@ -84,14 +84,18 @@ public class SmartQueue {
 		commandData.removeIf(data -> existing.stream().anyMatch(p -> CommandUtils.isEqual(p, data)));
 		slashData.removeIf(data -> existing.stream().anyMatch(p -> CommandUtils.isEqual(p, data)));
 		// remove unknown commands, if enabled
-		if (!commands.isEmpty() && removeUnknown) {
+		if (!commands.isEmpty()) {
 			for (Command command : commands) {
 				if (existing.contains(command)) {
-					DIH4JDALogger.info(String.format("Deleting unknown %s command: %s", command.getType(), command.getName()), DIH4JDALogger.Type.SMART_QUEUE);
-					if (guild == null) {
-						jda.deleteCommandById(command.getId()).queue();
+					if (deleteUnknown) {
+						DIH4JDALogger.info(String.format("Deleting unknown %s command: %s", command.getType(), command.getName()), DIH4JDALogger.Type.SMART_QUEUE);
+						if (guild == null) {
+							jda.deleteCommandById(command.getId()).queue();
+						} else {
+							guild.deleteCommandById(command.getId()).queue();
+						}
 					} else {
-						guild.deleteCommandById(command.getId()).queue();
+						DIH4JDALogger.info(String.format("Ignored unknown %s command: %s", command.getType(), command.getName()), DIH4JDALogger.Type.SMART_QUEUE);
 					}
 				}
 			}

--- a/src/main/java/com/dynxsty/dih4jda/SmartQueue.java
+++ b/src/main/java/com/dynxsty/dih4jda/SmartQueue.java
@@ -40,7 +40,7 @@ public class SmartQueue {
 	}
 
 	/**
-	 * Compares CommandData with already existing Commands, removed duplicates and, if enabled, deleted unknown commands.
+	 * Compares CommandData with already existing Commands, removed duplicates and, if enabled, deletes unknown commands.
 	 *
 	 * @param guild       The {@link Guild} which is used to retrieve the already existing commands.
 	 * @param slashData   The set of {@link SlashCommandData}.


### PR DESCRIPTION
I have made it possible to disable the automatic deletion of unknown commands when using the SmartQueue feature. 

While this might not be used by many people, it can be useful for those that can't have their commands deleted if they aren't used by something using DIH4JDA. Might be especially useful since a disabled SmartQueue overrides all commands, therefore also deleting unknown commands