### PR TITLE
Dependency update (JDA and gradle)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,10 +44,10 @@ repositories {
 
 
 dependencies {
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.2")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.2")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.0")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.0")
 
-    implementation("net.dv8tion:JDA:5.0.0-alpha.17")
+    implementation("net.dv8tion:JDA:5.0.0-alpha.19")
 }
 
 tasks.withType<JavaCompile> {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
JDA: `v5.0.0-alpha.17` -> `v5.0.0-alpha.19` 
Gradle: `7.5.0` -> `7.5.1`

Nothing breaking, but relevant due to the fact that DIH4JDA actively includes JDA.