### PR TITLE
add limit to filterChoices

### DIFF
--- a/src/main/java/xyz/dynxsty/dih4jda/util/AutoCompleteUtils.java
+++ b/src/main/java/xyz/dynxsty/dih4jda/util/AutoCompleteUtils.java
@@ -1,18 +1,22 @@
 package xyz.dynxsty.dih4jda.util;
 
-import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
-import net.dv8tion.jda.api.interactions.commands.Command;
-
-import javax.annotation.Nonnull;
 import java.util.List;
 
+import javax.annotation.Nonnull;
+
+import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.Command;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+
 /**
- * Utility class that contains some useful methods regarding the AutoComplete system.
+ * Utility class that contains some useful methods regarding the AutoComplete
+ * system.
  *
  * @since v1.4
  */
 public class AutoCompleteUtils {
-	private AutoCompleteUtils() {}
+	private AutoCompleteUtils() {
+	}
 
 	/**
 	 * Filters all AutoComplete choices based on the user's current input.
@@ -21,14 +25,15 @@ public class AutoCompleteUtils {
 	 * return event.replyChoices(AutoCompleteUtils.filterChoices(event, choices));
 	 * }</pre>
 	 *
-	 * @param event   The {@link CommandAutoCompleteInteractionEvent} that was fired.
+	 * @param event   The {@link CommandAutoCompleteInteractionEvent} that was
+	 *                fired.
 	 * @param choices A {@link List} of {@link Command.Choice}s.
 	 * @return The filtered {@link List} of {@link Command.Choice}s.
 	 * @since v1.4
 	 */
 	@Nonnull
 	public static List<Command.Choice> filterChoices(@Nonnull CommandAutoCompleteInteractionEvent event,
-															  @Nonnull List<Command.Choice> choices) {
+			@Nonnull List<Command.Choice> choices) {
 		return filterChoices(event.getFocusedOption().getValue().toLowerCase(), choices);
 	}
 
@@ -39,14 +44,15 @@ public class AutoCompleteUtils {
 	 * return event.replyChoices(AutoCompleteUtils.filterChoices(event, choices));
 	 * }</pre>
 	 *
-	 * @param event   The {@link CommandAutoCompleteInteractionEvent} that was fired.
+	 * @param event   The {@link CommandAutoCompleteInteractionEvent} that was
+	 *                fired.
 	 * @param choices An array of {@link Command.Choice}s.
 	 * @return The filtered {@link List} of {@link Command.Choice}s.
 	 * @since v1.4
 	 */
 	@Nonnull
 	public static List<Command.Choice> filterChoices(@Nonnull CommandAutoCompleteInteractionEvent event,
-															 @Nonnull Command.Choice... choices) {
+			@Nonnull Command.Choice... choices) {
 		return filterChoices(event.getFocusedOption().getValue().toLowerCase(), List.of(choices));
 	}
 
@@ -64,8 +70,11 @@ public class AutoCompleteUtils {
 	 */
 	@Nonnull
 	public static List<Command.Choice> filterChoices(@Nonnull String filter, @Nonnull List<Command.Choice> choices) {
-		choices.removeIf(choice -> !choice.getName().toLowerCase().contains(filter.toLowerCase()));
-		return choices;
+		return choices
+				.stream()
+				.filter(choice -> choice.getName().toLowerCase().contains(filter.toLowerCase()))
+				.limit(OptionData.MAX_CHOICES)
+				.toList();
 	}
 
 	/**

--- a/src/main/java/xyz/dynxsty/dih4jda/util/AutoCompleteUtils.java
+++ b/src/main/java/xyz/dynxsty/dih4jda/util/AutoCompleteUtils.java
@@ -1,6 +1,7 @@
 package xyz.dynxsty.dih4jda.util;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 
@@ -74,7 +75,7 @@ public class AutoCompleteUtils {
 				.stream()
 				.filter(choice -> choice.getName().toLowerCase().contains(filter.toLowerCase()))
 				.limit(OptionData.MAX_CHOICES)
-				.toList();
+				.collect(Collectors.toList());
 	}
 
 	/**


### PR DESCRIPTION
## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [ ] Documentation
- [ ] Added examples
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Currently, `AutoCompleteUtils#filterChoices` allows more than 25 choices. However, this will yield an error when being passed to `CommandAutoCompleteInteractionEvent#replyChoices`. This PR makes sure that `AutoCompleteUtils#filterChoices` only accepts a maximum of 25 choices and ignores any choices exceeding that limit.
Furthermore, it uses streams for achieving this task so that no `UnsupportedOperationException` is thrown when using this method with an unmodifiable list (like `filterChoices(String filter, Command.Choice...)` does).